### PR TITLE
Features/filtering hashtags 2

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,4 +3,4 @@ REACT_APP_CHAIN_HOST=http://localhost:8545
 REACT_APP_CHAIN_NAME=Localchain
 REACT_APP_TORUS_BUILD_ENV=testing
 REACT_APP_UPLOAD_HOST=http://localhost:8080
-APP_DEFAULT_TAGS="foodee,food,cooking,cuisine,kitchen,cucina"
+APP_DEFAULT_TAGS="foodee,sushilovers,sushipics,foodblogger,restaurant"

--- a/.env.sample
+++ b/.env.sample
@@ -3,4 +3,4 @@ REACT_APP_CHAIN_HOST=http://localhost:8545
 REACT_APP_CHAIN_NAME=Localchain
 REACT_APP_TORUS_BUILD_ENV=testing
 REACT_APP_UPLOAD_HOST=http://localhost:8080
-APP_DEFAULT_TAGS="foodee,sushilovers,sushipics,foodblogger,restaurant"
+APP_DEFAULT_TAGS="sushilovers,sushipics,foodblogger,restaurant"

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
-REACT_APP_CHAIN_ID=1337
+REACT_APP_CHAIN_ID=31337
 REACT_APP_CHAIN_HOST=http://localhost:8545
 REACT_APP_CHAIN_NAME=Localchain
 REACT_APP_TORUS_BUILD_ENV=testing
 REACT_APP_UPLOAD_HOST=http://localhost:8080
+APP_DEFAULT_TAGS="foodee,food,cooking,cuisine,kitchen,cucina"

--- a/config/env.js
+++ b/config/env.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const fs = require("fs");
 const path = require("path");
 const paths = require("./paths");
@@ -87,6 +85,7 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_HOST: process.env.WDS_SOCKET_HOST,
         WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
+        APP_DEFAULT_TAGS: process.env.APP_DEFAULT_TAGS,
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin

--- a/scripts/populate.mjs
+++ b/scripts/populate.mjs
@@ -2,6 +2,8 @@ import { setConfig, core, createRegistration } from "@dsnp/sdk";
 import { providers, Wallet } from "ethers";
 import fetch from "node-fetch";
 import web3 from "web3-utils";
+import { createReadStream } from "fs";
+import path from "path";
 
 import dotenv from "dotenv";
 dotenv.config();
@@ -42,6 +44,10 @@ const accounts = [
         "https://www.dietandi.com/wp-content/uploads/2011/11/Eating-Cereal.jpg"
       ),
     ],
+    tag: [
+      {name: "cereal"},
+      {name: "salad"},
+    ]
   },
   {
     address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
@@ -53,7 +59,12 @@ const accounts = [
         "https://brooklynfarmgirl.com/wp-content/uploads/2015/06/Mexican-Taco-Salsa-Hot-Dog_12.jpg"
       ),
     ],
-    text: "Hot take: Hotdogs aren't a sandwich, they're a taco",
+    text: "Hot take: A hotdog's not a sandwich, it's a taco",
+    tag: [
+      {name: "#taco"},
+      {name: "#hotdogs"},
+      {name: "this is another hashtag"}
+    ]
   },
   {
     address: "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
@@ -69,6 +80,7 @@ const accounts = [
       "Sometimes life is like this dark tunnel. You can’t always " +
       "see the light at the end of the tunnel, but if you just " +
       "keep moving, you will come to a better place.",
+    tag: {name: "a single tag"},
   },
   {
     address: "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
@@ -81,6 +93,7 @@ const accounts = [
       ),
     ],
     text: "Сухие завтраки - это разновидность салата. Конец истории.",
+    tag: ["cereal","salad","cухие","салата"]
   },
   {
     address: "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65",
@@ -91,6 +104,7 @@ const accounts = [
     ],
     text: "This Vimeo -- WAT. Amirite?",
     name: "Louis Bollen",
+    tag: [{name: "not foodblogger"},{name: "shouldn't appear"}]
   },
   {
     address: "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
@@ -99,6 +113,7 @@ const accounts = [
     name: "Anderson Penn",
     text:
       "My favorite sea shanty is 'Friggin in the Riggin'. I don't like attachments. That's why I don't have any.",
+    tag: {name: "another single tag"},
   },
   {
     address: "0x976ea74026e726554db657fa54763abd0c3a0aa9",
@@ -193,7 +208,13 @@ const accounts = [
         "https://image.shutterstock.com/image-photo/british-blue-kitten-very-beautiful-260nw-796071583.jpg"
       ),
     ],
-    text: "My favorite cartoon is Spongebob",
+    text: "I really love sushi!!",
+    tag: [
+      {name: "sushi"},
+      {name: "restaurant"},
+      {name: "sushipics"},
+      {name: ""}
+    ]
   },
   {
     address: "0xfabb0ac9d68b0b445fb7357272ff202c5651694a",
@@ -207,6 +228,7 @@ const accounts = [
     ],
     text:
       "The pizza shop down the street is giving out free donuts. Kinda sketchy",
+    tag: [{name: "pizza"},{name: "cucina"},{name: "Italian"},{name: "sketch"},{name: "restaurant"}]
   },
   {
     address: "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec",
@@ -266,6 +288,7 @@ const accounts = [
       ),
     ],
     text: "My favorite cartoon is Spongebob",
+    tag: {name: "foodblogger"}
   },
   {
     address: "0xdd2fd4581271e230360230f9337d5c0430bf44c0",
@@ -293,6 +316,7 @@ const accounts = [
     ],
     text:
       "Darn it, Jim, I'm a family doctor, not a swearing doctor! For pity's sake Jim, this is prime time!",
+    tag: [{type: "Mention", name: "restaurant"}]
   },
 ];
 
@@ -411,6 +435,25 @@ const storeAnnouncement = async (content, accountId, signer) => {
   return { hash, announcement };
 };
 
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const storeAvatar = async (handle) => {
+  await fetch(
+    `${process.env.REACT_APP_UPLOAD_HOST}/upload?filename=${handle + ".jpg"}`,
+    {
+      method: "POST",
+      body: createReadStream(`${__dirname}/avatars/${handle}.jpg`),
+    }
+  );
+  return core.activityContent.createImageLink(
+    `${process.env.REACT_APP_UPLOAD_HOST}/${handle}.jpg`,
+    "image/jpg",
+    [core.activityContent.createHash("0x123")],
+    { height: 72, width: 72 }
+  );
+};
+
+// register each account, and store store profile and note for them.
 for await (let account of accounts.values()) {
   console.log("Setting up account", account.address);
 
@@ -427,27 +470,33 @@ for await (let account of accounts.values()) {
   // register handle to get dsnp id
   account.id = await createRegistration(account.address, account.handle);
 
+  // store avatar
+  const avatar = await storeAvatar(account.handle);
+
   // create profile
   const profile = core.activityContent.createProfile({
     name: account.name,
+    icon: [avatar],
   });
+  profile.published = Date.now.toString(16);
 
   // create a note
   const content = core.activityContent.createNote(
     `${account.text} \n--from ${account.id}`,
     { attachment: account.attachment }
   );
-    content.published = new Date().toISOString();
+  content.published = new Date().toISOString();
+  if (account.tag) content.tag = account.tag
 
   const {
     hash: profileHash,
     announcement: profileAnnouncement,
   } = await storeAnnouncement(profile, account.id, wallet);
 
-      const {
-        hash: contentHash,
-        announcement: noteAnnouncement,
-      } = await storeAnnouncement(content, account.id, wallet);
+  const {
+    hash: contentHash,
+    announcement: noteAnnouncement,
+  } = await storeAnnouncement(content, account.id, wallet);
 
   const hash = web3.keccak256(profileHash + contentHash);
 

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -40,7 +40,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
         <ActionsBar published={feedItem.published} />
         <div>{noteContent.content}</div>
         <div className="Post__captionTags">
-          {feedItem.tags && feedItem.tags[0]}
+          {feedItem.tags && feedItem.tags.join(", ")}
         </div>
       </div>
     </Card>

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -3,11 +3,9 @@ import Post from "./Post";
 import { FeedItem, Graph } from "../utilities/types";
 import { useAppSelector } from "../redux/hooks";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
-import { HexString } from "@dsnp/sdk/dist/types/types/Strings";
 import {
   ActivityContentHashtag,
   ActivityContentMention,
-  ActivityContentNote,
   ActivityContentTag,
 } from "@dsnp/sdk/core/activityContent";
 import Masonry from "react-masonry-css";
@@ -35,9 +33,6 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
   const feed: FeedItem[] = useAppSelector((state) => state.feed.feed).filter(
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
-  const profiles: Record<HexString, Profile> = useAppSelector(
-    (state) => state.profiles?.profiles || {}
-  );
 
   const isAHashTag = (
     tag: ActivityContentTag | ActivityContentMention | undefined
@@ -59,9 +54,7 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
     } else return checkTags(tagList);
   };
 
-  const getTagListFromPost = (
-    feedItem: FeedItem<ActivityContentNote>
-  ): Array<string> => {
+  const getTagListFromPost = (feedItem: FeedItem): Array<string> => {
     if (!feedItem.content.tag) return [];
 
     const tagList: Array<ActivityContentTag> = !Array.isArray(
@@ -76,7 +69,7 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
     return mapped; // should never be blank
   };
 
-  let currentFeed: FeedItem<ActivityContentNote>[] = [];
+  let currentFeed: FeedItem[] = [];
 
   if (feedType === FeedTypes.FEED) {
     const addrSet = userId ? { [userId]: true } : {};
@@ -104,8 +97,6 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
 
       const namedPost: FeedItem = {
         ...post,
-        fromAddress: fromAddress,
-        timestamp: post.timestamp,
         tags: getTagListFromPost(post),
       };
       return <Post key={index} feedItem={namedPost} />;

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -3,6 +3,13 @@ import Post from "./Post";
 import { FeedItem, Graph } from "../utilities/types";
 import { useAppSelector } from "../redux/hooks";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { HexString } from "@dsnp/sdk/dist/types/types/Strings";
+import {
+  ActivityContentHashtag,
+  ActivityContentMention,
+  ActivityContentNote,
+  ActivityContentTag,
+} from "@dsnp/sdk/core/activityContent";
 import Masonry from "react-masonry-css";
 
 enum FeedTypes {
@@ -10,6 +17,8 @@ enum FeedTypes {
   MY_POSTS,
   ALL_POSTS,
 }
+
+const appDefaultTags = (process.env.APP_DEFAULT_TAGS || "foodee").split(",");
 
 interface PostListProps {
   feedType: FeedTypes;
@@ -26,15 +35,60 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
   const feed: FeedItem[] = useAppSelector((state) => state.feed.feed).filter(
     (post) => post?.content?.type === "Note" && post?.inReplyTo === undefined
   );
-  let currentFeed: FeedItem[] = [];
+  const profiles: Record<HexString, Profile> = useAppSelector(
+    (state) => state.profiles?.profiles || {}
+  );
+
+  const isAHashTag = (
+    tag: ActivityContentTag | ActivityContentMention | undefined
+  ): boolean => !!tag?.name && !("type" in tag);
+
+  const checkTags = (tag: ActivityContentHashtag | ActivityContentMention) => {
+    if (!isAHashTag(tag)) return false;
+    const res = appDefaultTags.some((dt) => dt === tag.name?.replace("#", ""));
+    return res;
+  };
+
+  const hasAppDefaultTag = (
+    tagList: ActivityContentTag | Array<ActivityContentTag> | undefined
+  ): boolean => {
+    if (!tagList) return false;
+    if (Array.isArray(tagList)) {
+      console.log("taglist: ", tagList);
+      return tagList.some((tag) => checkTags(tag));
+    } else return checkTags(tagList);
+  };
+
+  const getTagListFromPost = (
+    feedItem: FeedItem<ActivityContentNote>
+  ): Array<string> => {
+    if (!feedItem.content.tag) return [];
+
+    const tagList: Array<ActivityContentTag> = !Array.isArray(
+      feedItem.content.tag
+    )
+      ? [feedItem.content.tag]
+      : feedItem.content.tag;
+
+    const filtered = tagList.filter((t) => hasAppDefaultTag(t));
+    console.log("filtered: ", filtered);
+    const mapped = filtered.map((filteredTag) => filteredTag.name || "");
+    return mapped; // should never be blank
+  };
+
+  let currentFeed: FeedItem<ActivityContentNote>[] = [];
 
   if (feedType === FeedTypes.FEED) {
     const addrSet = userId ? { [userId]: true } : {};
     myGraph?.following.forEach((addr) => (addrSet[addr] = true));
     currentFeed = feed.filter((post) => post?.fromId in addrSet);
+    currentFeed = feed.filter((post) => {
+      return post?.fromAddress in addrSet || hasAppDefaultTag(post.content.tag);
+    });
   } else if (feedType === FeedTypes.MY_POSTS) {
     currentFeed = feed.filter((post) => userId === post?.fromId);
   } else {
+    // All Posts
     currentFeed = feed;
   }
 
@@ -50,7 +104,9 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
 
       const namedPost: FeedItem = {
         ...post,
-        tags: ["#foodee"],
+        fromAddress: fromAddress,
+        timestamp: post.timestamp,
+        tags: getTagListFromPost(post),
       };
       return <Post key={index} feedItem={namedPost} />;
     });


### PR DESCRIPTION
## Purpose
[Finishes #179255870](https://www.pivotaltracker.com/story/show/179255870)

## Solution
Make Foodee display only items tagged with what's in the linked story.  This is **NOT** a feature to be merged back to example-client. It is **ONLY** for the demo.

## Change summary
* Filtering done via .env environment variables.
* Populate script adds some tags to some posts.
* Filtering is done within PostList
* We strip any leading "#" characters.

Steps to Verify
----------------
1. Copy .env.sample to .env to get the final list of tags to filter on.
2.  Set up Foodee to run against a local hardhat note, and run the static-server, and run the updated populate.mjs script to add events with demo-relevant content. 
3. Login to Foodee.
4. There shouldn't be any posts showing in All Posts that don't have tags that are in the list.

Additional details / screenshot
----------------
- Any supplemental pictures or material
- 
![Screen Shot 2021-08-17 at 11 26 07 AM](https://user-images.githubusercontent.com/502640/129780570-945f9625-43b0-4a99-af52-f427c287e3c8.png)
