### PR TITLE
UI cleanup

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -23,3 +23,8 @@
 code {
   background-color: $gray;
 }
+
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,9 @@ import { setupProvider, startSubscriptions } from "./services/sdk";
 import PostList from "./components/PostList";
 
 enum FeedTypes {
-  FEED,
+  MY_FEED,
   MY_POSTS,
-  ALL_POSTS,
+  DISCOVER,
 }
 
 const App = (): JSX.Element => {
@@ -50,7 +50,7 @@ const App = (): JSX.Element => {
     };
   });
 
-  const [feedType, setFeedType] = useState<FeedTypes>(FeedTypes.ALL_POSTS);
+  const [feedType, setFeedType] = useState<FeedTypes>(FeedTypes.DISCOVER);
 
   return (
     <Router>

--- a/src/components/ConnectionsList.tsx
+++ b/src/components/ConnectionsList.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import { Button } from "antd";
 import ConnectionsListProfiles from "./ConnectionsListProfiles";
 import { useAppSelector } from "../redux/hooks";
 import { DSNPUserId } from "@dsnp/sdk/dist/types/core/identifiers";
+import { FeedItem } from "../utilities/types";
 
 enum ListStatus {
   CLOSED,
@@ -14,6 +14,12 @@ const ConnectionsList = (): JSX.Element => {
   const userId: DSNPUserId | undefined = useAppSelector(
     (state) => state.user.id
   );
+
+  const feed: FeedItem[] = useAppSelector((state) => state.feed.feed);
+  const myPostsCount = feed.filter(
+    (feedItem) => feedItem.fromAddress === userId && feedItem.inReplyTo === null
+  ).length;
+
   const following = useAppSelector(
     (state) => (userId && state.graphs.following[userId]) || {}
   );
@@ -42,7 +48,11 @@ const ConnectionsList = (): JSX.Element => {
   return (
     <div className="ConnectionsList__block">
       <div className="ConnectionsList__buttonBlock">
-        <Button
+        <button className="ConnectionsList__button">
+          <div className="ConnectionsList__buttonCount">{myPostsCount}</div>
+          Posts
+        </button>
+        <button
           className={getClassName(ListStatus.FOLLOWERS)}
           onClick={() => handleClick(ListStatus.FOLLOWERS)}
         >
@@ -50,12 +60,8 @@ const ConnectionsList = (): JSX.Element => {
             {Object.keys(followers).length}
           </div>
           Followers
-        </Button>
-
-        {selectedListTitle === ListStatus.CLOSED && (
-          <div className="ConnectionsList__buttonSeparator"> </div>
-        )}
-        <Button
+        </button>
+        <button
           className={getClassName(ListStatus.FOLLOWING)}
           onClick={() => handleClick(ListStatus.FOLLOWING)}
         >
@@ -63,7 +69,7 @@ const ConnectionsList = (): JSX.Element => {
             {Object.keys(following).length}
           </div>
           Following
-        </Button>
+        </button>
       </div>
       <ConnectionsListProfiles
         listStatus={selectedListTitle}

--- a/src/components/FeedNavigation.tsx
+++ b/src/components/FeedNavigation.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import {Button} from "antd";
-import {useAppSelector} from "../redux/hooks";
 
 enum FeedTypes {
-  FEED,
+  MY_FEED,
   MY_POSTS,
-  ALL_POSTS,
+  DISCOVER,
 }
 
 interface FeedNavigationProps {
@@ -14,11 +12,9 @@ interface FeedNavigationProps {
 }
 
 const FeedNavigation = ({
-                          feedType,
-                          setFeedType,
-                        }: FeedNavigationProps): JSX.Element => {
-  const userId = useAppSelector((state) => state.user.id);
-
+  feedType,
+  setFeedType,
+}: FeedNavigationProps): JSX.Element => {
   const feedNavClassName = (navItemType: number) =>
     feedType === navItemType
       ? "Feed__navigationItem Feed__navigationItem--active"
@@ -30,15 +26,15 @@ const FeedNavigation = ({
         <nav className="Feed__navigation">
           <div
             className={feedNavClassName(2)}
-            onClick={() => setFeedType(FeedTypes.ALL_POSTS)}
+            onClick={() => setFeedType(FeedTypes.DISCOVER)}
           >
-            All Posts
+            Discover
           </div>
           <div
             className={feedNavClassName(0)}
-            onClick={() => setFeedType(FeedTypes.FEED)}
+            onClick={() => setFeedType(FeedTypes.MY_FEED)}
           >
-            Feed
+            My Feed
           </div>
           <div
             className={feedNavClassName(1)}
@@ -47,7 +43,6 @@ const FeedNavigation = ({
             My Posts
           </div>
         </nav>
-        {userId && <Button className="Feed__newPostButton">New Post</Button>}
       </div>
     </div>
   );

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -38,7 +38,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
         <ActionsBar published={feedItem.published} />
         <div>{noteContent.content}</div>
         <div className="Post__captionTags">
-          {feedItem.tags && feedItem.tags.join(", ")}#sushilovers
+          {feedItem.tags && feedItem.tags.join(", ")}
         </div>
       </div>
     </Card>

--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -26,10 +26,10 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
         avatar={
           <UserAvatar profileAddress={feedItem.fromId} avatarSize={"medium"} />
         }
-        title={feedItem.fromAddress}
+        title={profiles[feedItem.fromId].name || feedItem.fromId}
         description={
           <div className="Post__description">
-            {profiles[feedItem.fromId].name}
+            @{profiles[feedItem.fromId].handle}
           </div>
         }
       />
@@ -38,7 +38,7 @@ const Post = ({ feedItem }: PostProps): JSX.Element => {
         <ActionsBar published={feedItem.published} />
         <div>{noteContent.content}</div>
         <div className="Post__captionTags">
-          {feedItem.tags && feedItem.tags.join(", ")}
+          {feedItem.tags && feedItem.tags.join(", ")}#sushilovers
         </div>
       </div>
     </Card>

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -11,15 +11,15 @@ import {
 import Masonry from "react-masonry-css";
 
 enum FeedTypes {
-  FEED,
+  MY_FEED,
   MY_POSTS,
-  ALL_POSTS,
+  DISCOVER,
 }
 
 const appDefaultTags: Array<string> = process.env.APP_DEFAULT_TAGS
   ? process.env.APP_DEFAULT_TAGS.split(",")
   : [];
-console.log("appDefaultTags: ", appDefaultTags);
+
 interface PostListProps {
   feedType: FeedTypes;
 }
@@ -72,7 +72,7 @@ const PostList = ({ feedType }: PostListProps): JSX.Element => {
 
   let currentFeed: FeedItem[] = [];
 
-  if (feedType === FeedTypes.FEED) {
+  if (feedType === FeedTypes.MY_FEED) {
     currentFeed = feed.filter(
       (post) => post?.fromId === userId || post?.fromId in myGraph
     );

--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -24,13 +24,13 @@ const getRelativeTime = (postTime: string) => {
   const currentTime = new Date();
   const secondsPast = (currentTime.getTime() - timeOfPost.getTime()) / 1000;
   if (secondsPast < 60) {
-    return Math.floor(secondsPast) + "s •";
+    return Math.floor(secondsPast) + "s";
   }
   if (secondsPast < 3600) {
-    return Math.floor(secondsPast / 60) + "m •";
+    return Math.floor(secondsPast / 60) + "m";
   }
   if (secondsPast <= 86400) {
-    return Math.floor(secondsPast / 3600) + "h •";
+    return Math.floor(secondsPast / 3600) + "h";
   }
   if (secondsPast > 86400) {
     return `${getMonthName(

--- a/src/components/scss/Post.scss
+++ b/src/components/scss/Post.scss
@@ -1,3 +1,7 @@
+.Post__block {
+  overflow: hidden;
+}
+
 .Post__description {
   @include small-text;
   line-height: 1;
@@ -15,6 +19,7 @@
   font-weight: bold;
   color: $white;
   padding: 30px;
+  hyphens: auto;
 }
 
 .Post__captionTags {

--- a/src/theme/_typography.scss
+++ b/src/theme/_typography.scss
@@ -33,9 +33,11 @@
 
 @mixin extra-large-text {
   font-family: CaslonGraphique, serif;
-  font-size: 52px;
+  font-size: 48px;
   font-weight: bold;
   letter-spacing: 1px;
+  line-height: 1.2;
+  hyphens: auto;
 }
 
 @mixin large-text {


### PR DESCRIPTION
Purpose
---------------
feature
[https://www.pivotaltracker.com/story/show/179289461](url)

Solution/Change summary
---------------
remove new post button
contain the width of the window to not have overflow
display long hashtags well (hyphenate and make the font smaller)
change the naming of the feeds to "Discover", "My Feed", "My Posts"
remove dots after timestamp

Steps to Verify
----------------
1. Check UI


Additional details / screenshot
----------------
<img width="1516" alt="Screen Shot 2021-08-19 at 4 21 26 PM" src="https://user-images.githubusercontent.com/43625033/130156508-393265be-794e-488a-a30c-5dab3e2ae40f.png">
